### PR TITLE
feat(query): add parsed data to error response

### DIFF
--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -29,8 +29,8 @@ export default class QueryBuilder {
       },
       ...options
     })
-      .then(checkStatus)
       .then(parseJSON)
+      .then(checkStatus)
   }
 
   get query() {

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -17,8 +17,8 @@ export default class QueryBuilder {
       headers: headersToSend,
       ...options
     })
-      .then(checkStatus)
       .then(parseJSON)
+      .then(checkStatus)
   }
 
   nonInstanceFetch(url, options, headers) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,7 @@ export function checkStatus(response) {
 
   try {
     error = new Error(response.data.detail)
-  } catch (e) {
+  } catch (err) {
     error = new Error(response.statusText)
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,10 @@ export function parseJSON(response) {
   const mimetype = response.headers.get('Content-Type')
 
   if (response.status === 204 || mimetype === null) {
-    return Promise.resolve()
+    return Promise.resolve({
+      data: undefined,
+      ...response
+    })
   }
 
   // Parse JSON

--- a/tests/e2e/class.js
+++ b/tests/e2e/class.js
@@ -23,11 +23,7 @@ describe('Class', function () {
       })
       .catch(err => {
         console.log(err)
-        err.response.text()
-          .then(text => {
-            console.log(text)
-            done(err)
-          })
+        done(err)
       })
   })
 
@@ -49,11 +45,6 @@ describe('Class', function () {
       })
       .catch(err => {
         console.log(err)
-        err.response.text()
-          .then(str => {
-            console.log(str)
-            done(err)
-          })
         done(err)
       })
   })


### PR DESCRIPTION
```
// ...
.catch(({data})=> {
  console.log(data) // Now you have parsed response via data key
})
```